### PR TITLE
Fix WebUSB and model detection for 1st Gen Portals

### DIFF
--- a/src/lib/adb/connection.ts
+++ b/src/lib/adb/connection.ts
@@ -5,7 +5,17 @@ import {
 } from "@yume-chan/adb-daemon-webusb";
 import { credentialStore } from "./credential-store";
 
-const USB_FILTER = { vendorId: 0x2ec6 };
+/**
+ * WebUSB vendor-ID filters for Meta Portal devices.
+ *
+ * - 0x2ec6  Meta Platforms USB VID (Portal Gen 2+, Portal Go, Portal TV)
+ * - 0x18d1  Google ADB VID (Portal Gen 1 — codename "aloha" uses product ID
+ *           0x1804)
+ */
+const USB_FILTERS: USBDeviceFilter[] = [
+	{ vendorId: 0x2ec6 },
+	{ vendorId: 0x18d1, productId: 0x1804 },
+];
 
 let manager: AdbDaemonWebUsbDeviceManager | undefined;
 
@@ -29,13 +39,13 @@ export async function requestDevice(): Promise<
 > {
 	const mgr = getManager();
 	if (!mgr) return undefined;
-	return mgr.requestDevice({ filters: [USB_FILTER] });
+	return mgr.requestDevice({ filters: USB_FILTERS });
 }
 
 export async function getPairedDevices(): Promise<AdbDaemonWebUsbDevice[]> {
 	const mgr = getManager();
 	if (!mgr) return [];
-	return mgr.getDevices({ filters: [USB_FILTER] });
+	return mgr.getDevices({ filters: USB_FILTERS });
 }
 
 export async function connectDevice(

--- a/src/lib/portal/models.ts
+++ b/src/lib/portal/models.ts
@@ -1,11 +1,11 @@
 export type PortalModel =
 	| "omni"
-	| "portal-2019"
+	| "portal-1"
 	| "portal-plus-1"
+	| "portal-2019"
 	| "portal-plus-2"
 	| "portal-go"
 	| "portal-tv"
-	| "portal-1"
 	| "unknown";
 
 // Marketing/topology metadata only — anything the device reports itself
@@ -19,7 +19,29 @@ export interface PortalModelInfo {
 	hasScreen: boolean;
 }
 
+/**
+ * Map of internal device codenames (from `ro.product.device`) to Portal model
+ * metadata. Gen 1 devices use the Google ADB VID (0x18d1) while Gen 2+
+ * devices use Meta's own VID (0x2ec6).
+ */
 const MODELS: Record<string, PortalModelInfo> = {
+	// ── Gen 1 ────────────────────────────────────────────────────────────
+	aloha: {
+		codename: "portal-1",
+		displayName: "Portal (1st Gen)",
+		generation: 1,
+		screenSize: '10.1"',
+		hasScreen: true,
+	},
+	portopalma: {
+		codename: "portal-plus-1",
+		displayName: "Portal+ (1st Gen)",
+		generation: 1,
+		screenSize: '15.6"',
+		hasScreen: true,
+	},
+
+	// ── Gen 2 ────────────────────────────────────────────────────────────
 	omni: {
 		codename: "omni",
 		displayName: "Portal Mini",
@@ -27,7 +49,7 @@ const MODELS: Record<string, PortalModelInfo> = {
 		screenSize: '8"',
 		hasScreen: true,
 	},
-	aloha: {
+	"aloha-2": {
 		codename: "portal-2019",
 		displayName: "Portal (2nd Gen)",
 		generation: 2,


### PR DESCRIPTION
## Summary

- Add Google ADB USB filter (`0x18d1` / product `0x1804`) so 1st Gen Portals appear in the WebUSB device picker and can connect
- Correct `aloha` codename mapping to Portal (1st Gen) instead of 2nd Gen
- Add `portopalma` as Portal+ (1st Gen) and move the 2nd Gen 10" mapping to the `aloha-2` codename

## Test plan

- [ ] Connect a 1st Gen Portal (`aloha`) over USB — device should appear in the browser WebUSB picker
- [ ] After connecting, dashboard should show **Portal (1st Gen)** with generation 1
- [ ] Connect a 2nd Gen Portal — still connects via Meta VID (`0x2ec6`) and shows correct model
- [ ] `pnpm lint` and `pnpm build` pass


Made with [Cursor](https://cursor.com)